### PR TITLE
To fix the crash during termination and actually killing the cnode

### DIFF
--- a/lib/nodex/cnode.ex
+++ b/lib/nodex/cnode.ex
@@ -129,7 +129,7 @@ defmodule Nodex.Cnode do
   end
 
   def terminate(_reason, %{os_pid: os_pid}) when os_pid != nil do
-    System.cmd("kill", ["-9", os_pid])
+    System.cmd("kill", ["-9", "#{os_pid}"])
     :normal
   end
 


### PR DESCRIPTION
**Issue** : When `terminate` hook is triggered for the Genserver and it runs the system command to kill the actual `cnode` , it runs into the following `ArgumentError` and the `cnode` is never terminated.

**Error** :
```
12:43:50.092 [error] GenServer #PID<0.203.0> terminating
** (ArgumentError) all arguments for System.cmd/3 must be binaries
    (elixir 1.10.3) lib/system.ex:786: System.cmd/3
    (nodex 0.1.1) lib/nodex/cnode.ex:132: Nodex.Cnode.terminate/2
    (stdlib 3.12.1) gen_server.erl:673: :gen_server.try_terminate/3
    (stdlib 3.12.1) gen_server.erl:858: :gen_server.terminate/10
    (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:nodedown, :"ExampleClient@127.0.0.1"}
State: %{cnode: :"ExampleClient@127.0.0.1", exec_path: "priv/example_client", hostname: "127.0.0.1", os_pid: 90596, ready_line: "ExampleClient@127.0.0.1 ready", sname: :ExampleClient, spawn_inactive_timeout: 5000}
** (EXIT from #PID<0.191.0>) shell process exited with reason: an exception was raised:
    ** (ArgumentError) all arguments for System.cmd/3 must be binaries
        (elixir 1.10.3) lib/system.ex:786: System.cmd/3
        (nodex 0.1.1) lib/nodex/cnode.ex:132: Nodex.Cnode.terminate/2
        (stdlib 3.12.1) gen_server.erl:673: :gen_server.try_terminate/3
        (stdlib 3.12.1) gen_server.erl:858: :gen_server.terminate/10
        (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

**Steps to reproduce** :

1. Start the `cnode` with following.
`Nodex.Cnode.start_link(%{exec_path: "priv/example_client", sname: :ExampleClient, hostname: "127.0.0.1"})`
2. Disconnect the node with following.
`Node.disconnect(:"ExampleClient@127.0.0.1")`
